### PR TITLE
Builder to support environment variable as a macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,7 @@ The following types are supported in expressions:
 
 ### Variables
 
+- Variable can be defined by `-DMyVarName MyVarValue` command line parameter, read from [runtime environment](#environment-variables), or defined by <code><b>@set</b></code> statements.
 - Variables defined by <code><b>@set</b></code> statements are available in expressions.
 - Undefined variables are evaluated as `null`.
 - Variable names can contain `$`, `_`, latin letters and digits. They must not start with a digit.
@@ -465,6 +466,16 @@ loop.index: 1
 myvar: 9
 loop.index: 2
 ```
+
+#### Environment variables
+
+There is no special predicate to use environment variables. **Builder** tries to resolve macro from context provided by command line defines or from process environment variables. [`Command line defines`](#usage) has higher priority then environment variables.
+
+```
+server.log("Host home path is @{HOME}");
+```
+
+This will print home folder of current logged user at the system where **Builder** was executed.
 
 ### Functions
 

--- a/src/Expression.js
+++ b/src/Expression.js
@@ -316,6 +316,7 @@ class Expression {
           res = context[node.name];
         } else /* environment */ {
           res = process.env[node.name];
+          if (!res) res = null;
         }
 
         break;

--- a/src/Expression.js
+++ b/src/Expression.js
@@ -312,9 +312,10 @@ class Expression {
           context.hasOwnProperty(node.name) && typeof context[node.name] === 'function'
         ) {
           res = node.name;
-        } else /* variable */ {
-          res = context.hasOwnProperty(node.name)
-            ? context[node.name] : null;
+        } else /* variable */ if (context.hasOwnProperty(node.name)) {
+          res = context[node.name];
+        } else /* environment */ {
+          res = process.env[node.name];
         }
 
         break;


### PR DESCRIPTION
The fix is not what was requested exactly, but may more useful as doesn't require special keyword. So now Builder looks for macro at command line defines, then at special file and at process environment at last.